### PR TITLE
Update versions, fix for Middleman v4-alpha

### DIFF
--- a/lib/middleman-asciidoc.rb
+++ b/lib/middleman-asciidoc.rb
@@ -1,7 +1,5 @@
 require 'middleman-core'
 require 'middleman-asciidoc/version'
+require 'middleman-asciidoc/extension'
 
-Middleman::Extensions.register :asciidoc do
-  require 'middleman-asciidoc/extension'
-  Middleman::AsciiDoc::AsciiDocExtension
-end
+::Middleman::Extensions.register(:asciidoc, Middleman::AsciiDoc::AsciiDocExtension)

--- a/lib/middleman-asciidoc/extension.rb
+++ b/lib/middleman-asciidoc/extension.rb
@@ -24,7 +24,7 @@ module Middleman
 
       def manipulate_resource_list(resources)
         resources.each do |resource|
-          path = resource.source_file
+          path = resource.request_path
           next unless path.present? && File.extname(path) == '.adoc'
 
           # read the AsciiDoc header only to set page options and data

--- a/middleman-asciidoc.gemspec
+++ b/middleman-asciidoc.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.test_files = `git ls-files -z -- {fixtures,features}/*`.split "\0"
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'middleman-core', ['>= 4.0.0.pre.0', '< 4.1']
-  s.add_runtime_dependency 'asciidoctor', '~> 0.1.4'
+  s.add_runtime_dependency 'middleman-core', ['>= 4.0.0.alpha.0']
+  s.add_runtime_dependency 'asciidoctor', '~> 1.5.2'
 end


### PR DESCRIPTION
I've been using these two succesfully in my site:

```ruby
gem 'middleman-asciidoc', :git => 'https://github.com/ciarand/middleman-asciidoc', :branch => 'updated-versions'
gem "middleman", "~> 4.0.0.alpha.6"
```