### PR TITLE
Fixed failing test due to wrong HTML structure

### DIFF
--- a/features/asciidoc.feature
+++ b/features/asciidoc.feature
@@ -77,12 +77,8 @@ Feature: AsciiDoc Support
       </head>
       <body>
       <h1>Page Title</h1>
-      <div id="preamble">
-      <div class="sectionbody">
       <div class="paragraph">
       <p>Hello, AsciiDoc!</p>
-      </div>
-      </div>
       </div>
       </body>
       </html>


### PR DESCRIPTION
My guess is, that this HTML block should look just like the others (i.e. no preamble or section divs).