### PR TITLE
resolves #13 generate standalone document if page-layout is unset

### DIFF
--- a/fixtures/asciidoc-app/source/hello-no-layout.adoc
+++ b/fixtures/asciidoc-app/source/hello-no-layout.adoc
@@ -1,2 +1,2 @@
-:page-layout: false
+:page-layout!:
 Hello, AsciiDoc!


### PR DESCRIPTION
- set default page-layout when loading document
- enable header_footer option when page-layout is unset
- use auto layout when page-layout is empty
- cascade page layout from site config to front matter to header attribute