### PR TITLE
Added support for :imagesdir:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ doc
 tmp
 Makefile
 .mm-pid-*
+.idea


### PR DESCRIPTION
I've changed the behaviour how the "imagesdir" is configured. Until now the imagesdir was always configured the way that it used the :images_dir from middleman. Due to that the :imagesdir: inside an adoc file was ignored. With the changes in this commit the :imagesdir: inside the adoc files is used and the images_dir from middleman is used as a fallback.