### PR TITLE
rewrite #24 enable more configuration options for imagesdir

### DIFF
--- a/features/asciidoc.feature
+++ b/features/asciidoc.feature
@@ -153,6 +153,33 @@ Feature: AsciiDoc Support
       </div>
       """
 
+  Scenario: Linking to an image with a custom imagesdir
+    Given the Server is running at "asciidoc-app"
+    When I go to "/custom-imagesdir.html"
+    Then I should see:
+      """
+      <div class="imageblock">
+      <div class="content">
+      <img src="img/tiger.gif" alt="tiger">
+      </div>
+      """
+
+  Scenario: imagesdir configuratino should override imagesdir defined in page
+    Given a fixture app "asciidoc-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, :asciidoc_attributes => %w(imagesdir=/img)
+      """
+    Given the Server is running at "asciidoc-app"
+    When I go to "/custom-imagesdir.html"
+    Then I should see:
+      """
+      <div class="imageblock">
+      <div class="content">
+      <img src="/img/tiger.gif" alt="tiger">
+      </div>
+      """
+
   Scenario: Configuring custom AsciiDoc attributes
     Given a fixture app "asciidoc-app"
     And a file named "config.rb" with:

--- a/fixtures/asciidoc-app/source/custom-imagesdir.adoc
+++ b/fixtures/asciidoc-app/source/custom-imagesdir.adoc
@@ -1,0 +1,3 @@
+:imagesdir: img
+
+image::tiger.gif[]

--- a/lib/middleman-asciidoc/extension.rb
+++ b/lib/middleman-asciidoc/extension.rb
@@ -18,8 +18,8 @@ module Middleman
       def after_configuration
         # QUESTION should base_dir be equal to docdir instead?
         app.config[:asciidoc][:base_dir] = app.source_dir.expand_path.to_s
+        app.config[:asciidoc][:attributes] << %(imagesdir=#{File.join((app.config[:http_prefix] || '/').chomp('/'), app.config[:images_dir])}@)
         app.config[:asciidoc][:attributes].concat Array(options[:asciidoc_attributes])
-        app.config[:asciidoc][:attributes] << %(imagesdir=#{File.join((app.config[:http_prefix] || '/').chomp('/'), app.config[:images_dir])})
         # QUESTION should we convert attributes to a map at this point?
       end
 


### PR DESCRIPTION
- allow page to override imagesdir by default
- allow imagesdir to be configured independently in site configuration