### PR TITLE
resolves #27 allow base_dir to be set; default to docdir

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ activate :asciidoc
 You can also pass AsciiDoc configuration options to the underlying Asciidoctor processor:
 
 ```ruby
-activate :asciidoc, :asciidoc_attributes => %w(foo=bar)
+activate :asciidoc, :attributes => %w(foo=bar)
 ```
 
 The full set of options can be seen on your preview server's config page at [path]_/__middleman/config/_.

--- a/features/asciidoc.feature
+++ b/features/asciidoc.feature
@@ -142,6 +142,35 @@ Feature: AsciiDoc Support
       </div>
       """
 
+  Scenario: Including a file relative to document in subdirectory
+    Given the Server is running at "asciidoc-app"
+    When I go to "/manual/index.html"
+    Then I should see:
+      """
+      <h1>Manual</h1>
+      <div class="sect1">
+      <h2 id="_chapter_01">Chapter 01</h2>
+      <div class="sectionbody">
+      <div class="paragraph">
+      <p>content</p>
+      </div>
+      </div>
+      </div>
+      """
+
+  Scenario: Including a file relative to document in subdirectory when base_dir is set
+    Given a fixture app "asciidoc-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, base_dir: app.source_dir.expand_path
+      """
+    Given the Server is running at "asciidoc-app"
+    When I go to "/manual/index.html"
+    Then I should see:
+      """
+      <p>Unresolved directive in &lt;stdin&gt; - include::_chapters/ch01.adoc[]</p>
+      """
+
   Scenario: Linking to an image
     Given the Server is running at "asciidoc-app"
     When I go to "/gallery.html"
@@ -168,7 +197,7 @@ Feature: AsciiDoc Support
     Given a fixture app "asciidoc-app"
     And a file named "config.rb" with:
       """
-      activate :asciidoc, :asciidoc_attributes => %w(imagesdir=/img)
+      activate :asciidoc, attributes: %w(imagesdir=/img)
       """
     Given the Server is running at "asciidoc-app"
     When I go to "/custom-imagesdir.html"
@@ -184,7 +213,7 @@ Feature: AsciiDoc Support
     Given a fixture app "asciidoc-app"
     And a file named "config.rb" with:
       """
-      activate :asciidoc, :asciidoc_attributes => %w(foo=bar)
+      activate :asciidoc, attributes: %w(foo=bar)
       """
     Given the Server is running at "asciidoc-app"
     When I go to "/custom-attribute.html"
@@ -194,7 +223,7 @@ Feature: AsciiDoc Support
     Given a fixture app "asciidoc-app"
     And a file named "config.rb" with:
       """
-      activate :asciidoc, :asciidoc_attributes => %w(source-highlighter=html-pipeline)
+      activate :asciidoc, attributes: %w(source-highlighter=html-pipeline)
       """
     Given the Server is running at "asciidoc-app"
     When I go to "/code.html"

--- a/fixtures/asciidoc-app/source/manual/_chapters/ch01.adoc
+++ b/fixtures/asciidoc-app/source/manual/_chapters/ch01.adoc
@@ -1,0 +1,3 @@
+== Chapter 01
+
+content

--- a/fixtures/asciidoc-app/source/manual/index.adoc
+++ b/fixtures/asciidoc-app/source/manual/index.adoc
@@ -1,0 +1,4 @@
+= Manual
+:showtitle:
+
+include::_chapters/ch01.adoc[]


### PR DESCRIPTION
- allow base_dir option to be set
- set base_dir to nil by default
- if base_dir is nil, set base_dir to docdir for each document
- add tests to verify base_dir can be set; has proper behavior
- rename asciidoc_attributes option to attributes
- allow backend to be set; default to :html5
- allow safe to be set; default to :safe
- support legacy asciidoc_attributes global option
- optimize after_configuration logic