### PR TITLE
promote attributes to top-level option on page directive

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -151,6 +151,32 @@ The name of the default layout for AsciiDoc-based pages (pages processed by this
 
 TIP: The full set of options can be seen on your preview server's config page at the path [.path]_/__middleman/config/_.
 
+=== Configuring Specific Pages
+
+You can pass extra attributes and other options to the AsciiDoc processor for a given page (or set of pages) using the `:renderer_options` option of the `page` directive (where the "`renderer`" is the AsciiDoc processor):
+
+[source,ruby]
+----
+page 'manual', renderer_options: {
+  attributes: { 'sectanchors' => '' }
+}
+----
+
+NOTE: The first argument to the `page` directive is the page ID.
+The page ID is computed by starting with the path of the source file relative to the source directory, then removing the template extension (i.e., the AsciiDoc extension), then removing the `.html` extension, if present.
+For example, the page ID for both [.path]_home.adoc_ and [.path]_home.html.adoc_ is `home`.
+
+WARNING: Attributes passed to the page directive must be specified as a Hash and receive no additional processing.
+
+You can add extra attributes to a page more concisely using the `:attributes` option on the page directive:
+
+[source,ruby]
+----
+page 'manual', attributes: { 'sectanchors' => '' }
+----
+
+The `:attributes` option on the page directive takes precedence over the `:attributes` option in `:renderer_options`.
+
 == Creating Pages
 
 Each AsciiDoc file in the source directory (except for files that begin with `+_+` or which are located in a directory that begins with `+_+`) becomes a page in the site.
@@ -225,17 +251,13 @@ Alternately, you can set a default layout just for AsciiDoc-based pages (pages p
 activate :asciidoc, layout: :name_of_layout
 ----
 
-Finally, you can set the layout for a specific page or group of pages using the page directive.
+Finally, you can set the layout for a specific page or group of pages using the `page` directive.
 This is an alternate way to define front matter for a page.
 
 [source,ruby]
 ----
 page 'home', layout: :name_of_layout
 ----
-
-NOTE: The first argument to the `page` function is the page ID.
-The page ID is computed starting from the path of the source file relative to the source directory, then removing the template extension (i.e., the AsciiDoc extension), then removing the `.html` extension, if present.
-For example, the page ID for both [.path]_home.adoc_ and [.path]_home.html.adoc_ is `home`.
 
 TIP: When you define the layout in [.path]_config.rb_, you can specify the value either as a String or a Symbol.
 

--- a/features/asciidoc-pages.feature
+++ b/features/asciidoc-pages.feature
@@ -740,6 +740,16 @@ Feature: AsciiDoc Support
       <h2 id="_section_a"><a class="anchor" href="#_section_a"></a>Section A</h2>
       """
 
+  Scenario: Setting custom attributes for a specific page abbrev
+    Given a fixture app "asciidoc-pages-app"
+    And app "asciidoc-pages-app" is using config "page-attributes-abbrev"
+    And the Server is running
+    When I go to "/with-sections.html"
+    Then I should see:
+      """
+      <h2 id="_section_a"><a class="anchor" href="#_section_a"></a>Section A</h2>
+      """
+
   Scenario: Using custom templates to convert AsciiDoc document nodes to HTML
     Given a fixture app "asciidoc-pages-app"
     And a file named "config.rb" with:

--- a/fixtures/asciidoc-pages-app/config-page-attributes-abbrev.rb
+++ b/fixtures/asciidoc-pages-app/config-page-attributes-abbrev.rb
@@ -1,0 +1,2 @@
+activate :asciidoc
+page 'with-sections', attributes: { 'sectanchors' => '' }

--- a/lib/middleman-asciidoc/extension.rb
+++ b/lib/middleman-asciidoc/extension.rb
@@ -98,9 +98,17 @@ module Middleman
             page_attrs['docdir'] = (dir = ::File.dirname path)
             page_attrs['docname'] = ::File.basename path, (page_attrs['docfilesuffix'] = ::File.extname path)
           end
-          if (page_asciidoc_opts = resource.options.delete :renderer_options)
-            (page_asciidoc_opts[:attributes] ||= {}).update page_attrs
+          # handle options set using the page directive
+          # :attributes key on page directive takes precedence over :attributes key in :asciidoc option
+          initial_page_attrs = resource.options.delete :attributes
+          if ::Hash === (page_asciidoc_opts = resource.options.delete :asciidoc)
+            if ::Hash === initial_page_attrs ||
+                ::Hash === (initial_page_attrs = page_asciidoc_opts.delete :attributes)
+              page_attrs = initial_page_attrs.merge page_attrs
+            end
+            page_asciidoc_opts[:attributes] = page_attrs
           else
+            page_attrs = initial_page_attrs.merge page_attrs if ::Hash === initial_page_attrs
             page_asciidoc_opts = { attributes: page_attrs }
           end
           opts, page = { renderer_options: page_asciidoc_opts }, {}


### PR DESCRIPTION
- promote attributes to top-level option on page directive; add test
- validate type of renderer_options and attributes on page before using
- document configuring options per-page