### PR TITLE
resolves #78 pass to_dir option to AsciiDoc processor

### DIFF
--- a/features/asciidoc-pages.feature
+++ b/features/asciidoc-pages.feature
@@ -394,6 +394,11 @@ Feature: AsciiDoc Support
     And I should see content matching %r{<p>site-destination=.+/tmp/aruba/asciidoc-pages-app/build</p>}
     And I should see content matching %r{<p>site-environment=development</p>}
 
+  Scenario: Sets value of to_dir option on parsed document
+    Given the Server is running at "asciidoc-pages-app"
+    When I go to "/page-data.html"
+    Then I should see content matching %r{<p>to_dir=.+/tmp/aruba/asciidoc-pages-app/build</p>}
+
   Scenario: Assigning page ID to page-id attribute
     Given the Server is running at "asciidoc-pages-app"
     When I go to "/topic/echo-page-id.html"

--- a/features/asciidoc-pages.feature
+++ b/features/asciidoc-pages.feature
@@ -394,6 +394,16 @@ Feature: AsciiDoc Support
     And I should see content matching %r{<p>site-destination=.+/tmp/aruba/asciidoc-pages-app/build</p>}
     And I should see content matching %r{<p>site-environment=development</p>}
 
+  Scenario: Publishing document information as AsciiDoc attributes
+    Given the Server is running at "asciidoc-pages-app"
+    When I go to "/document-information.html"
+    Then I should see content matching %r{<p>docdir=.+/tmp/aruba/asciidoc-pages-app/source</p>}
+    And I should see content matching %r{<p>docfile=.+/tmp/aruba/asciidoc-pages-app/source/document-information.adoc</p>}
+    And I should see "<p>docfilesuffix=.adoc</p>"
+    And I should see "<p>docname=document-information</p>"
+    And I should see content matching %r{<p>outdir=.+/tmp/aruba/asciidoc-pages-app/build</p>}
+    And I should see content matching %r{<p>outfile=.+/tmp/aruba/asciidoc-pages-app/build/document-information.html</p>}
+
   Scenario: Sets value of to_dir option on parsed document
     Given the Server is running at "asciidoc-pages-app"
     When I go to "/page-data.html"

--- a/fixtures/asciidoc-pages-app/source/document-information.adoc
+++ b/fixtures/asciidoc-pages-app/source/document-information.adoc
@@ -1,0 +1,8 @@
+= Doc Information
+
+* docdir={docdir}
+* docfile={docfile}
+* docfilesuffix={docfilesuffix}
+* docname={docname}
+* outdir={outdir}
+* outfile={outfile}

--- a/fixtures/asciidoc-pages-app/source/layouts/inspect-page-data.erb
+++ b/fixtures/asciidoc-pages-app/source/layouts/inspect-page-data.erb
@@ -7,5 +7,6 @@
 <pre>{<%= current_resource.data.keys.sort.map {|k|
   %("#{k}"=>#{(k == 'document' ? current_resource.data[k].doctitle : (JSON.load current_resource.data[k].to_json)).inspect })
 } * ', ' %>}</pre>
+<p>to_dir=<%= current_resource.data.document.options[:to_dir] %></p>
 </body>
 </html>

--- a/lib/middleman-asciidoc/template.rb
+++ b/lib/middleman-asciidoc/template.rb
@@ -8,9 +8,11 @@ module Middleman; module AsciiDoc
     def prepare
       opts = DEFAULT_OPTIONS.merge options
       if (ctx = middleman_context)
-        opts[:to_dir] = ::File.dirname ::File.join \
+        attrs = opts[:attributes]
+        attrs['outfile'] = outfile = ::File.join \
             (ctx.app.root_path.join ctx.app.config[:build_dir].to_s),
             ctx.current_page.destination_path
+        attrs['outdir'] = opts[:to_dir] = ::File.dirname outfile
       end
       @document = ::Asciidoctor.load data, opts
       ctx.current_page.data.document = @document if ctx

--- a/lib/middleman-asciidoc/template.rb
+++ b/lib/middleman-asciidoc/template.rb
@@ -6,15 +6,25 @@ module Middleman; module AsciiDoc
     DEFAULT_OPTIONS = { header_footer: false }
 
     def prepare
-      @document = ::Asciidoctor.load data, (DEFAULT_OPTIONS.merge options)
-      if ::Middleman::TemplateContext === (ctx = options[:context])
-        ctx.current_page.data.document = @document
+      opts = DEFAULT_OPTIONS.merge options
+      if (ctx = middleman_context)
+        opts[:to_dir] = ::File.dirname ::File.join \
+            (ctx.app.root_path.join ctx.app.config[:build_dir].to_s),
+            ctx.current_page.destination_path
       end
+      @document = ::Asciidoctor.load data, opts
+      ctx.current_page.data.document = @document if ctx
       @output = nil
     end
 
     def evaluate scope, locals
       @output ||= @document.convert
+    end
+
+    def middleman_context
+      if ::Middleman::TemplateContext === (ctx = options[:context])
+        ctx
+      end
     end
   end
 


### PR DESCRIPTION
- pass to_dir option to AsciiDoc processor when loading document
- to_dir option should subsequently be accessible via parsed document