### PR TITLE
resolves #87 respect requested file extension; add tests

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -248,6 +248,32 @@ For example, to reference the site title, you'd use:
 If you want to support nested properties (e.g., `site.blog.title`), you can refactor the code above into a function you can call recursively.
 The convention is to flatten these paths into attribute names using the hyphen character (e.g., `site-blog-title`).
 
+=== Customizing the Output File Extension
+
+By default, the extension of an output file created from an AsciiDoc document is `.html`.
+If you want to customize this extension, for example to change it to `.jsp`, there are two ways to do so.
+
+First, you can give the AsciiDoc source document a double file extension, such as `.jsp.adoc`.
+In this case, the second file extension (`.adoc`) tells Middleman the file is an AsciiDoc file and the first file extension (`.jsp`) tells Middleman which extension to use for the output file.
+
+If you're working with existing AsciiDoc documents, you may not want to change the file extension from `.adoc`.
+In this case, you must set the `outfilesuffix` AsciiDoc attribute, either globally:
+
+[source,ruby]
+----
+activate :asciidoc, attributes: ['outfilesuffix=.jsp']
+----
+
+or per page you want to customize:
+
+[source,ruby]
+----
+page 'manual', attributes: { 'outfilesuffix' =>  '.jsp' }
+----
+
+Note that setting the outfilesuffix has no effect on a file with a double file extension.
+When the file has a double file extension, the first extension is always used as the extension for the output file.
+
 == Creating Pages
 
 Each AsciiDoc file in the source directory (except for files that begin with `+_+` or which are located in a directory that begins with `+_+`) becomes a page in the site.

--- a/features/asciidoc-pages.feature
+++ b/features/asciidoc-pages.feature
@@ -12,7 +12,7 @@ Feature: AsciiDoc Support
       </div>
       """
 
-  Scenario: Rendering HTML page from AsciiDoc document with alternate extension
+  Scenario: Rendering HTML page from AsciiDoc document with alternate AsciiDoc extension
     Given the Server is running at "asciidoc-pages-app"
     When I go to "/goodbye.html"
     Then I should see:
@@ -22,9 +22,52 @@ Feature: AsciiDoc Support
       </div>
       """
 
-  Scenario: Rendering html with double file extension
+  Scenario: Rendering HTML page with double file extension
     Given the Server is running at "asciidoc-pages-app"
     When I go to "/hello-with-extension.html"
+    Then I should see:
+      """
+      <div class="paragraph">
+      <p>Hello, AsciiDoc!
+      Middleman, I am in you.</p>
+      </div>
+      """
+
+  Scenario: Rendering HTML page with custom outfilesuffix from AsciiDoc document
+    Given a fixture app "asciidoc-pages-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, attributes: %w(outfilesuffix=.jsp)
+      """
+    And the Server is running
+    When I go to "/hello.jsp"
+    Then I should see:
+      """
+      <div class="paragraph">
+      <p>Hello, AsciiDoc!
+      Middleman, I am in you.</p>
+      </div>
+      """
+
+  Scenario: Rendering HTML page from AsciiDoc document with double non-HTML file extension
+    Given the Server is running at "asciidoc-pages-app"
+    When I go to "/hello-with-alt-extension.jsp"
+    Then I should see:
+      """
+      <div class="paragraph">
+      <p>Hello, AsciiDoc!
+      Middleman, I am in you.</p>
+      </div>
+      """
+
+  Scenario: Rendering HTML page with custom outfilesuffix from AsciiDoc document with double non-HTML file extension
+    Given a fixture app "asciidoc-pages-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, attributes: %w(outfilesuffix=.jsp)
+      """
+    And the Server is running
+    When I go to "/hello-with-alt-extension.jsp"
     Then I should see:
       """
       <div class="paragraph">

--- a/fixtures/asciidoc-pages-app/source/hello-with-alt-extension.jsp.adoc
+++ b/fixtures/asciidoc-pages-app/source/hello-with-alt-extension.jsp.adoc
@@ -1,0 +1,4 @@
+Hello, AsciiDoc!
+ifdef::site-gen-middleman[]
+Middleman, I am in you.
+endif::[]

--- a/lib/middleman-asciidoc/extension.rb
+++ b/lib/middleman-asciidoc/extension.rb
@@ -181,10 +181,9 @@ module Middleman
             page.update adoc_front_matter
           end
 
-          unless resource.ext == doc.outfilesuffix
-            # NOTE we must use << or else the layout gets disabled
-            resource.destination_path << doc.outfilesuffix
-          end
+          # NOTE we must modify value directly instead of reassigning or else layout gets disabled
+          # NOTE if resource.ext is not empty, it means the file has a double file extension (e.g., .jsp.adoc)
+          resource.destination_path << doc.outfilesuffix if resource.ext.empty?
 
           # NOTE only options[:renderer_options] overrides keys defined in global options
           resource.add_metadata options: opts, page: page


### PR DESCRIPTION
- if file has double file extension (.jsp.adoc), use the first file extension for the output file
- if file has a single file extension (.adoc), use value of outfilesuffix as file extension
- add tests for double file extension and outfilesuffix