### PR TITLE
resolves #94 add ability to promote custom attributes to page data and optionally replace dashes with underscores in their names

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,6 +133,14 @@ The following built-in attributes are automatically appended to this collection.
  ** can be overridden by page, hence the trailing @
 * imagesoutdir=(imagesdir relative to site destination)
 
+promoted_attributes (type: String Array, default: [])::
+List of attribute names in the document header to convert to page data (aka front matter).
+Refer to the <<Adding Custom Page Data>> section for details.
+
+promoted_attributes_convert_dashes (type: Boolean, default: false)::
+Whether to replace dashes in attribute names to underscores when promoting them to page data.
+Refer to the <<Adding Custom Page Data>> section for details.
+
 backend (type: Symbol, default: :html5)::
 The moniker for a converter, which determines the output format to generate.
 
@@ -302,9 +310,11 @@ puts "Hello, World!"
 
 AsciiDoc attributes defined in the document header whose names begin with `page-` are promoted to page data (aka front matter).
 The part of the name after the `page-` prefix is used as the entry's key (e.g., page-layout becomes layout).
+You can also set the `:promoted_attributes` option to provide a list of attributes that are always promoted without the `page-` prefix.
+If the `:promoted_attributes_convert_dashes` option is set to true, dashes in the attribute names are replaced with underscores (e.g., page-a-very-long-name becomes a_very_long_name).
 The value is parsed as {uri-yaml}[YAML] data (that which can be expressed in a single line).
 
-In addition to these explicit page attributes, the following AsciiDoc attributes are also promoted to page data:
+In addition to these explicit page attributes and the `:promoted_attributes` option, the following AsciiDoc attributes are also promoted to page data:
 
 * doctitle (i.e., the document title) (becomes title)
 * author (becomes author.name)

--- a/features/asciidoc-pages.feature
+++ b/features/asciidoc-pages.feature
@@ -484,6 +484,32 @@ Feature: AsciiDoc Support
       <pre>{"document"=>"Page Data", "id"=>"page-data", "title"=>"Page Data", "v-chrarray"=>["a", "b", "c"], "v-dblquote"=>"\"", "v-empty"=>"", "v-false"=>false, "v-hash"=>{"a"=>"a", "b"=>"b", "c"=>"c"}, "v-null"=>nil, "v-num"=>1, "v-numarray"=>[1, 2, 3], "v-quote"=>"'", "v-true"=>true}</pre>
       """
 
+  Scenario: Promote attributes to page data using promoted_attributes option
+    Given a fixture app "asciidoc-pages-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, promoted_attributes: ['regular-attribute']
+      """
+    And the Server is running
+    When I go to "/page-data.html"
+    Then I should see:
+      """
+      <pre>{"document"=>"Page Data", "id"=>"page-data", "regular-attribute"=>"I am a regular attribute", "title"=>"Page Data", "v-chrarray"=>["a", "b", "c"], "v-dblquote"=>"\"", "v-empty"=>"", "v-false"=>false, "v-hash"=>{"a"=>"a", "b"=>"b", "c"=>"c"}, "v-null"=>nil, "v-num"=>1, "v-numarray"=>[1, 2, 3], "v-quote"=>"'", "v-true"=>true}</pre>
+      """
+
+  Scenario: Convert dashes to underscores when promoting custom attributes to page data if promoted_attributes_convert_dashes option is true
+    Given a fixture app "asciidoc-pages-app"
+    And a file named "config.rb" with:
+      """
+      activate :asciidoc, promoted_attributes: ['regular-attribute'], promoted_attributes_convert_dashes: true
+      """
+    And the Server is running
+    When I go to "/page-data.html"
+    Then I should see:
+      """
+      <pre>{"document"=>"Page Data", "id"=>"page-data", "regular_attribute"=>"I am a regular attribute", "title"=>"Page Data", "v_chrarray"=>["a", "b", "c"], "v_dblquote"=>"\"", "v_empty"=>"", "v_false"=>false, "v_hash"=>{"a"=>"a", "b"=>"b", "c"=>"c"}, "v_null"=>nil, "v_num"=>1, "v_numarray"=>[1, 2, 3], "v_quote"=>"'", "v_true"=>true}</pre>
+      """
+
   Scenario: Promoting standard AsciiDoc attributes to page data
     Given the Server is running at "asciidoc-pages-app"
     When I go to "/inspect-standard-page-data.html"

--- a/fixtures/asciidoc-pages-app/source/page-data.adoc
+++ b/fixtures/asciidoc-pages-app/source/page-data.adoc
@@ -10,3 +10,4 @@
 :page-v-numarray: [1, 2, 3]
 :page-v-chrarray: [a, b, c]
 :page-v-hash: { a: a, b: b, c: c }
+:regular-attribute: I am a regular attribute

--- a/lib/middleman-asciidoc/extension.rb
+++ b/lib/middleman-asciidoc/extension.rb
@@ -20,6 +20,8 @@ module Middleman
       AttributeReferenceRx = /\\?\{(\w+(?:[\-]\w+)*)\}/
 
       option :attributes, {}, 'AsciiDoc attributes passed to all AsciiDoc-based pages. Defaults to empty Hash. (Hash or Array)'
+      option :promoted_attributes, [], 'List of attribute names in the document header to convert to page data (aka front matter). (Array)'
+      option :promoted_attributes_convert_dashes, false, 'Whether to replace dashes in attribute names to underscores when promoting them to page data. (Boolean)'
       option :backend, :html5, 'Moniker used to select output format for AsciiDoc-based pages. Defaults to :html5. (Symbol)'
       option :base_dir, :docdir, 'Base directory to use for the current AsciiDoc document. Defaults to :docdir, which resolves to the document directory. (String)'
       option :safe, :safe, 'Safe mode level for AsciiDoc processor. Defaults to :safe. (Symbol)'
@@ -249,9 +251,20 @@ module Middleman
       # Returns the page variable name as a [String] or nothing if the attribute name is not the name of a page
       # attribute.
       def derive_page_variable_name attribute_name
-        if attribute_name != 'page-layout' && attribute_name != 'page-layout-engine' && attribute_name != 'page-ignored' &&
-            (attribute_name.start_with? 'page-')
-          (attribute_name.slice 5, attribute_name.length).to_sym
+        if attribute_name != 'page-layout' && attribute_name != 'page-layout-engine' && attribute_name != 'page-ignored'
+          if attribute_name.start_with? 'page-'
+            derived_name = (attribute_name.slice 5, attribute_name.length)
+          elsif options[:promoted_attributes].include? attribute_name
+            derived_name = attribute_name
+          else
+            return nil
+          end
+
+          if options[:promoted_attributes_convert_dashes]
+            derived_name.gsub('-', '_').to_sym
+          else
+            derived_name.to_sym
+          end
         end
       end
 


### PR DESCRIPTION
I have also added the ability to replace `-` with `_` in page data attributes in addition to #94 , since page data is often written by the convention of words separated by `_` and attributes are by `-`, and writing attributes like `page-something_something` is kind of ugly. The default is still not doing that to maintain compatibility.