### PR TITLE
middleman compatibility with 4.6 (tilt ~> 2.2)

### DIFF
--- a/lib/middleman-asciidoc/template.rb
+++ b/lib/middleman-asciidoc/template.rb
@@ -16,10 +16,6 @@ module Middleman; module AsciiDoc
       end
       @document = ::Asciidoctor.load data, opts
       ctx.current_page.data.document = @document if ctx
-      @output = nil
-    end
-
-    def evaluate scope, locals
       @output ||= @document.convert
     end
 

--- a/middleman-asciidoc.gemspec
+++ b/middleman-asciidoc.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'middleman-core', '~> 4.0'
+  s.add_runtime_dependency 'middleman-core', '~> 4.6'
   s.add_runtime_dependency 'asciidoctor', '>= 1.5.0'
 end


### PR DESCRIPTION
In middleman 4.6, tilt is 2.2 or higher, but on tilt 2.2, there was a problem where render returned nil.

Upon investigation, it was found that starting from tilt 2.2, the parent class of `AsciidoctorTemplate` has been changed to `StaticTemplate`. In `StaticTemplate`, the `evaluate` method is not called during rendering; instead, rendering is completed during the `prepare` method, and only the `@output` is output.

To accommodate this code change, rendering is now completed solely during `prepare`, and the dependency version of middleman-core has been updated.